### PR TITLE
Fix dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Also includes fbxdump which allows you to inspect fbx files in json format.
 
 [FBX format description](https://code.blender.org/2013/08/fbx-binary-file-format-specification/)
 
-[FBX file structure](https://wiki.blender.org/index.php/User:Mont29/Foundation/FBX_File_Structure)
+[FBX file structure](https://web.archive.org/web/20160605023014/https://wiki.blender.org/index.php/User:Mont29/Foundation/FBX_File_Structure)
 
 # Javascript port
 


### PR DESCRIPTION
It probably makes sense to move this information from archive.org to some local Wiki pages in this repo?