### PR TITLE
fix some problems

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 3.8)
 project(fbx-writer)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -std=c++17 -lstdc++")
+if(CMAKE_COMPILER_IS_GNUCXX)
+    message(STATUS "GCC detected, adding compile flags")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -std=c++17 -lstdc++")
+endif(CMAKE_COMPILER_IS_GNUCXX)
 
 find_package( ZLIB REQUIRED )
 

--- a/src/fbxdocument.cpp
+++ b/src/fbxdocument.cpp
@@ -19,10 +19,12 @@ void FBXDocument::read(string fname)
 {
     ifstream file;
 
-    // buffer
-    int bufferSize = 1 << 16;
-    char buffer[bufferSize];
-    file.rdbuf()->pubsetbuf(buffer, bufferSize);
+	// buffer
+	int bufferSize = 1 << 16;
+	char *buffer;
+	buffer = (char *)malloc(sizeof(char) * bufferSize);
+	file.rdbuf()->pubsetbuf(buffer, bufferSize);
+	free(buffer);
 
     file.open(fname, std::ios::in | std::ios::binary);
     if (file.is_open()) {
@@ -37,10 +39,12 @@ void FBXDocument::write(string fname)
 {
     ofstream file;
 
-    // buffer
-    int bufferSize = 1 << 16;
-    char buffer[bufferSize];
-    file.rdbuf()->pubsetbuf(buffer, bufferSize);
+	// buffer
+	int bufferSize = 1 << 16;
+	char *buffer;
+	buffer = (char *)malloc(sizeof(char) * bufferSize);
+	file.rdbuf()->pubsetbuf(buffer, bufferSize);
+	free(buffer);
 
     file.open(fname, std::ios::out | std::ios::binary);
     if (file.is_open()) {

--- a/src/fbxdocument.cpp
+++ b/src/fbxdocument.cpp
@@ -301,4 +301,18 @@ void FBXDocument::print()
     cout << "\n  ]\n}" << endl;
 }
 
+void FBXDocument::log(ofstream &output)
+{
+	output << "{\n";
+	output << "  \"version\": " << getVersion() << ",\n";
+	output << "  \"children\": [\n";
+	bool hasPrev = false;
+	for (auto node : nodes) {
+		if (hasPrev) output << ",\n";
+		node.log("    ", output);
+		hasPrev = true;
+	}
+	output << "\n  ]\n}" << endl;
+}
+
 } // namespace fbx

--- a/src/fbxdocument.h
+++ b/src/fbxdocument.h
@@ -2,6 +2,8 @@
 #define FBXDOCUMENT_H
 
 #include "fbxnode.h"
+#include <fstream>
+using namespace std;
 
 namespace fbx {
 
@@ -20,6 +22,7 @@ public:
 
     std::uint32_t getVersion();
     void print();
+	void log(ofstream &output);
 
 private:
     std::uint32_t version;

--- a/src/fbxnode.cpp
+++ b/src/fbxnode.cpp
@@ -122,6 +122,35 @@ void FBXNode::print(std::string prefix)
 
 }
 
+void FBXNode::log(std::string prefix, std::ofstream &output)
+{
+	output << prefix << "{ \"name\": \"" << name << "\"" << (properties.size() + children.size() > 0 ? ",\n" : "\n");
+	if (properties.size() > 0) {
+		output << prefix << "  \"properties\": [\n";
+		bool hasPrev = false;
+		for (FBXProperty prop : properties) {
+			if (hasPrev) output << ",\n";
+			output << prefix << "    { \"type\": \"" << prop.getType() << "\", \"value\": " << prop.to_string() << " }";
+			hasPrev = true;
+		}
+		output << "\n";
+		output << prefix << "  ]" << (children.size() > 0 ? ",\n" : "\n");
+	}
+
+	if (children.size() > 0) {
+		output << prefix << "  \"children\": [\n";
+		bool hasPrev = false;
+		for (FBXNode node : children) {
+			if (hasPrev) output << ",\n";
+			node.log(prefix + "    ", output);
+			hasPrev = true;
+		}
+		output << "\n";
+		output << prefix << "  ]\n";
+	}
+	output << prefix << "}";
+}
+
 bool FBXNode::isNull()
 {
     return children.size() == 0

--- a/src/fbxnode.h
+++ b/src/fbxnode.h
@@ -2,6 +2,7 @@
 #define FBXNODE_H
 
 #include "fbxproperty.h"
+#include <fstream>
 
 namespace fbx {
 
@@ -14,6 +15,7 @@ public:
     std::uint32_t read(std::ifstream &input, uint32_t start_offset);
     std::uint32_t write(std::ofstream &output, uint32_t start_offset);
     void print(std::string prefix="");
+	void log(std::string, std::ofstream &output);
     bool isNull();
 
     void addProperty(int16_t);

--- a/src/fbxproperty.cpp
+++ b/src/fbxproperty.cpp
@@ -97,12 +97,14 @@ FBXProperty::FBXProperty(std::ifstream &input)
             if(decompressedBuffer == NULL) throw std::string("Malloc failed");
             BufferAutoFree baf(decompressedBuffer);
 
-            uint8_t compressedBuffer[compressedLength];
+			uint8_t *compressedBuffer;
+			compressedBuffer = (uint8_t *)malloc(sizeof(uint8_t) * compressedLength);
             reader.read((char*)compressedBuffer, compressedLength);
 
             uint64_t destLen = uncompressedLength;
             uint64_t srcLen = compressedLength;
-            uncompress2(decompressedBuffer, &destLen, compressedBuffer, &srcLen);
+            uncompress2(decompressedBuffer, (uLongf *)&destLen, compressedBuffer, (uLong *)&srcLen);
+			free(compressedBuffer);
 
             if(srcLen != compressedLength) throw std::string("compressedLength does not match data");
             if(destLen != uncompressedLength) throw std::string("uncompressedLength does not match data");

--- a/src/fbxutil.cpp
+++ b/src/fbxutil.cpp
@@ -99,10 +99,13 @@ uint64_t Reader::readUint64()
 
 std::string Reader::readString(uint32_t length)
 {
-    char buffer[length + 1];
-    buffer[length] = 0;
-    if(length) read(buffer, length);
-    return std::string(buffer);
+	char *buffer;
+	buffer = (char *)malloc(sizeof(char) * (length + 1));
+	buffer[length] = 0;
+	if (length) read(buffer, length);
+	std::string s = std::string(buffer);
+	free(buffer);
+	return s;
 }
 
 float Reader::readFloat()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 #include <stdint.h>
 #include <iostream>
-
+#include <string>
 #include "fbxdocument.h"
 
 using std::cout;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,7 +19,18 @@ int main(int argc, char** argv)
         std::cout << "Reading " << argv[1] << std::endl;
         doc.read(argv[1]);
 
-        //doc.print();
+		/////output fbx to txt/////////
+		{
+		std::string filename = argv[1];
+		filename = filename.substr(0, filename.rfind(".")) + ".txt";
+
+		ofstream f;
+		f.open(filename, ios::out);//開啟檔案
+        doc.log(f);
+		f.close();//關閉檔案
+		}
+		/////output fbx to txt/////////
+
         std::cout << "Writing test.fbx" << std::endl;
         doc.write("test.fbx");
     } catch(std::string e) {


### PR DESCRIPTION
1. Fix #5   by using malloc instead of direct use variable

2. fix compile problem
add compile flag only when detected GCC or can't compile if not using GCC

3. fix "no operator “<<” matches these operands" error in main.cpp
just include "string"

4. fix argument type is incompatible with parameter error